### PR TITLE
Enable flatpak maker

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -1,7 +1,7 @@
 import type { ForgeConfig } from '@electron-forge/shared-types';
 import { MakerAppImage } from 'electron-forge-maker-appimage';
 import { MakerPacman } from 'electron-forge-maker-pacman';
-// import { MakerFlatpak } from '@electron-forge/maker-flatpak';
+import { MakerFlatpak } from '@electron-forge/maker-flatpak';
 // import { MakerSnap } from '@electron-forge/maker-snap';
 import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
@@ -28,14 +28,15 @@ const config: ForgeConfig = {
       },
     }), 
     new MakerPacman({}),
-    // new MakerFlatpak({
-    //   options: {
-    //     files: 
-    //     productName: "Deezer Enhanced",
-    //     icon: "./build/icon.svg",
-    //     categories: ["Audio"],
-    //   }
-    // }), 
+    new MakerFlatpak({
+      options: {
+        files: [],
+        id: "org.duzda.deezer-enhanced",
+        productName: "Deezer Enhanced",
+        icon: "./build/icon.svg",
+        categories: ["Audio"],
+      }
+    }), 
     // new MakerSnap({
     //   features: {
     //     audio: true,

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -30,10 +30,40 @@ const config: ForgeConfig = {
     new MakerPacman({}),
     new MakerFlatpak({
       options: {
-        files: [],
+        files: [
+          ["build/icons/16x16.png","/share/icons/hicolor/16x16/apps/org.duzda.deezer-enhanced.png"],
+          ["build/icons/32x32.png","/share/icons/hicolor/32x32/apps/org.duzda.deezer-enhanced.png"],
+          ["build/icons/64x64.png","/share/icons/hicolor/64x64/apps/org.duzda.deezer-enhanced.png"],
+          ["build/icons/128x128.png","/share/icons/hicolor/128x128/apps/org.duzda.deezer-enhanced.png"],
+          ["build/icons/256x256.png","/share/icons/hicolor/256x256/apps/org.duzda.deezer-enhanced.png"],
+          ["build/icons/512x512.png","/share/icons/hicolor/512x512/apps/org.duzda.deezer-enhanced.png"]
+        ],
+        finishArgs: [
+            // Wayland Rendering
+            //"--socket=wayland",
+            //"--socket=fallback-x11",
+            // X Rendering
+            "--socket=x11",
+            "--share=ipc",
+            // Open GL
+            "--device=dri",
+            // Audio output
+            "--socket=pulseaudio",
+            // Read/write home directory access
+            "--filesystem=home",
+            // Chromium uses a socket in tmp for its singleton check
+            "--env=TMPDIR=/var/tmp",
+            // Allow communication with network
+            "--share=network",
+            // System notifications with libnotify
+            "--talk-name=org.freedesktop.Notifications",
+            // Override MPRIS name
+            "--own-name=org.mpris.MediaPlayer2.Deezer"
+        ],
         id: "org.duzda.deezer-enhanced",
         productName: "Deezer Enhanced",
-        icon: "./build/icon.svg",
+        // This doesn't work anyway
+        //icon: "build/icon.png",
         categories: ["Audio"],
       }
     }), 


### PR DESCRIPTION
Working flatpak maker. Might need few other tweaks for Discord and potentially for Flathub distribution.
Both Mpris and icons are working. Mpris name override is needed as we use Deezer, but flatpak expects full name corresponding to ID.