### PR TITLE
add adblocking per whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An unofficial application for Deezer with enhanced features.
 - Discord Rich Presence
 - Support for Steamdeck
 - Automatic dark mode switching
+- Adblocking
 
 # Where to get the app
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,32 @@ if (!gotTheLock) {
       }
     });
 
+    const hostWhitelist = [
+      'deezer.com',
+      'dzcdn.net',
+      'edgecastcdn.net',
+
+      // for login recaptcha
+      'google.com',
+      'gstatic.com',
+    ];
+
+    session.defaultSession.webRequest.onBeforeRequest(
+      { urls: ['*://*/*'] },
+      (details, callback) => {
+        const url = new URL(details.url);
+
+        for (let i = 0; i < hostWhitelist.length; i += 1) {
+          const w = hostWhitelist[i];
+          if (url.hostname === w || url.hostname.endsWith(`.${w}`)) {
+            callback({ cancel: false });
+            return;
+          }
+        }
+        callback({ cancel: true });
+      }
+    );
+
     const mainWindow = new BaseWindow({
       width: 800,
       height: 600,


### PR DESCRIPTION
this blocks the connections to following hosts, even happening with a payed account:
- braze.com
- segment.com
- facebook.com
- googletagmanager.com
- cdn-apple.com
- sentry.io