### PR TITLE
fix: use BaseWindow for 'second-instance' event handler

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,4 @@
-import {
-  app,
-  BaseWindow,
-  BrowserWindow,
-  session,
-  WebContentsView,
-} from 'electron';
+import { app, BaseWindow, session, WebContentsView } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import { createHistoryHandles } from './main/history';
@@ -206,8 +200,8 @@ if (!gotTheLock) {
   app.on('ready', createWindow);
 
   app.on('second-instance', () => {
-    if (BrowserWindow.getAllWindows().length > 0) {
-      const window = BrowserWindow.getAllWindows()[0];
+    if (BaseWindow.getAllWindows().length > 0) {
+      const window = BaseWindow.getAllWindows()[0];
       if (window.isMinimized() || !window.isVisible()) {
         window.show();
         return;


### PR DESCRIPTION
Hello, first of all thank you for this app :smile: 

This PR fix a small inconvenience I have. 
When I start a new instance of the app and the app is already started but in the tray, I would like the existing instance to be shown. 
The implementation seems to be intended that way, but currently it does nothing for me.

Re-using the `BaseWindow` instance in the `second-instance` handler works for me.

Tested on my machine with NixOS / Hyprland (wayland) 
I don't know if the current implementation using `BrowserWindow` is working as intended for anyone else though.

Steps to reproduce: 

- Start the app
- Check "Enable Tray" and "Close to tray" settings 
- Close the window (app is now in the tray)
- Start the app again (I expect the first instance to pop from the tray)