### PR TITLE
fix: add workaround for name in volume mixer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,8 @@ const HOST_BLACKLIST: ReadonlyArray<string> = [
 if (!gotTheLock) {
   app.quit();
 } else {
-  app.commandLine.appendSwitch('disable-features', 'MediaSessionService');
+  // AudioServiceOutOfProcess is a workaround for github.com/electron/electron/issues/27581 and can be removed once upstream merges a fix
+  app.commandLine.appendSwitch('disable-features', 'AudioServiceOutOfProcess,MediaSessionService');
 
   const createWindow = () => {
     session.defaultSession.setUserAgent(USER_AGENT);


### PR DESCRIPTION
This should fix #44 or rather work around the electron issue, that causes #44

Decided to create a PR since I was testing this for https://github.com/electron/electron/pull/49270 anyways.

Feel free to ignore