### PR TITLE
Add xesam:url to player metadata

### DIFF
--- a/src/main/mpris.ts
+++ b/src/main/mpris.ts
@@ -95,6 +95,7 @@ const updateMetadataSong = (player: Player, data: Song) => {
       data.ARTISTS !== undefined
         ? data.ARTISTS.map((artist) => artist.ART_NAME)
         : [data.ART_NAME],
+    'xesam:url': DEEZER_TRACK_URL + data.SNG_ID,
   };
 };
 
@@ -107,6 +108,7 @@ const updateMetadataEpisode = (player: Player, data: Episode) => {
     'xesam:title': data.EPISODE_TITLE,
     'xesam:album': data.SHOW_NAME,
     'xesam:artist': [data.SHOW_NAME],
+    'xesam:url': DEEZER_EPISODE_URL + data.EPISODE_ID,
   };
 };
 


### PR DESCRIPTION
This PR adds the SongUrl and EpisodeUrl to the mpris player metadata.

Before:
<img width="631" height="394" alt="2026_03_02_09_13_11" src="https://github.com/user-attachments/assets/ea2c9b94-9404-4b9f-b438-a046eded0b8f" />
After:
<img width="631" height="404" alt="2026_03_02_09_11_07" src="https://github.com/user-attachments/assets/d0c94add-7d15-4d38-93fc-f4ced69ea948" />
