### PR TITLE
feat: add setting to remember arl cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deezer-enhanced",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deezer-enhanced",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@jellybrick/mpris-service": "git+https://github.com/duzda/mpris-service",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "daisyui": "^5.5.14",
-        "electron": "^41.1.1",
+        "electron": "^37.10.3",
         "electron-forge-maker-appimage": "git+https://github.com/duzda/electron-forge-maker-appimage",
         "electron-forge-maker-pacman": "git+https://github.com/duzda/electron-forge-maker-pacman",
         "eslint": "^8.57.1",
@@ -5066,15 +5066,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
-      "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
+      "version": "37.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
+      "integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -5696,16 +5696,6 @@
         "global-agent": "^3.0.0"
       }
     },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "24.10.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
-      "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/electron/node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -5740,13 +5730,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/electron/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/electron/node_modules/universalify": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "daisyui": "^5.5.14",
-        "electron": "^40.4.1",
+        "electron": "^41.1.1",
         "electron-forge-maker-appimage": "git+https://github.com/duzda/electron-forge-maker-appimage",
         "electron-forge-maker-pacman": "git+https://github.com/duzda/electron-forge-maker-pacman",
         "eslint": "^8.57.1",
@@ -5066,9 +5066,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.4.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.4.1.tgz",
-      "integrity": "sha512-N1ZXybQZL8kYemO8vAeh9nrk4mSvqlAO8xs0QCHkXIvRnuB/7VGwEehjvQbsU5/f4bmTKpG+2GQERe/zmKpudQ==",
+      "version": "41.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
+      "integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deezer-enhanced",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "An unofficial application for Deezer with enhanced features.",
   "homepage": "https://github.com/duzda/deezer-enhanced",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "daisyui": "^5.5.14",
-    "electron": "^41.1.1",
+    "electron": "^37.10.3",
     "electron-forge-maker-appimage": "git+https://github.com/duzda/electron-forge-maker-appimage",
     "electron-forge-maker-pacman": "git+https://github.com/duzda/electron-forge-maker-pacman",
     "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "daisyui": "^5.5.14",
-    "electron": "^40.4.1",
+    "electron": "^41.1.1",
     "electron-forge-maker-appimage": "git+https://github.com/duzda/electron-forge-maker-appimage",
     "electron-forge-maker-pacman": "git+https://github.com/duzda/electron-forge-maker-pacman",
     "eslint": "^8.57.1",

--- a/src/common/types/settings.ts
+++ b/src/common/types/settings.ts
@@ -6,6 +6,7 @@ export interface Settings {
   deemixIntegration: boolean;
   volumePower: number;
   discordRPC: boolean;
+  adblock: boolean;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -16,6 +17,7 @@ export const DEFAULT_SETTINGS: Settings = {
   deemixIntegration: false,
   volumePower: 4,
   discordRPC: false,
+  adblock: false,
 };
 
 type Setter<T extends keyof Settings> = (newValue: Settings[T]) => void;

--- a/src/common/types/settings.ts
+++ b/src/common/types/settings.ts
@@ -7,6 +7,7 @@ export interface Settings {
   volumePower: number;
   discordRPC: boolean;
   adblock: boolean;
+  saveArl: boolean;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -18,6 +19,7 @@ export const DEFAULT_SETTINGS: Settings = {
   volumePower: 4,
   discordRPC: false,
   adblock: false,
+  saveArl: false,
 };
 
 type Setter<T extends keyof Settings> = (newValue: Settings[T]) => void;

--- a/src/common/types/settings.ts
+++ b/src/common/types/settings.ts
@@ -18,23 +18,8 @@ export const DEFAULT_SETTINGS: Settings = {
   discordRPC: false,
 };
 
-export type SettingsProperties =
-  | 'enableTray'
-  | 'closeToTray'
-  | 'startInTray'
-  | 'enableNotifications'
-  | 'deemixIntegration'
-  | 'volumePower'
-  | 'discordRPC';
-
-type Setter<T> = (newValue: T) => void | undefined;
+type Setter<T extends keyof Settings> = (newValue: Settings[T]) => void;
 
 export type Setters = {
-  enableTray: Setter<boolean>;
-  closeToTray: Setter<boolean>;
-  startInTray: Setter<boolean>;
-  enableNotifications: Setter<boolean>;
-  deemixIntegration: Setter<boolean>;
-  volumePower: Setter<number>;
-  discordRPC: Setter<boolean>;
+  [K in keyof Settings]: Setter<K>;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,11 +27,31 @@ const USER_AGENT =
 
 const gotTheLock = app.requestSingleInstanceLock();
 
-const HOST_BLACKLIST: ReadonlyArray<string> = [
-  'googletagmanager.com',
-  'segment.com',
-  'sentry.io',
-  'survicate.com',
+const HOST_WHITELIST: ReadonlyArray<string> = [
+  'deezer.com',
+  'dzcdn.net',
+  'edgecastcdn.net',
+
+  // Login recaptcha
+  'google.com',
+  'gstatic.com',
+
+  // Social logins
+  'appleid.cdn-apple.com',
+  'connect.facebook.net',
+  'appleid.apple.com',
+
+  // Social pages
+  'apple.com',
+  'facebook.com',
+  'accounts.youtube.com',
+
+  // Socials content
+  'static.xx.fbcdn.net',
+  'lh3.googleusercontent.com',
+  'is1-ssl.mzstatic.com',
+
+  'localhost',
 ];
 
 if (process.defaultApp) {
@@ -79,12 +99,17 @@ if (!gotTheLock) {
       (details, callback) => {
         const url = new URL(details.url);
 
-        if (HOST_BLACKLIST.some((host) => url.hostname.endsWith(host))) {
-          callback({ cancel: true });
+        if (!getSettings().adblock) {
+          callback({ cancel: false });
           return;
         }
 
-        callback({ cancel: false });
+        if (HOST_WHITELIST.some((host) => url.hostname.endsWith(host))) {
+          callback({ cancel: false });
+          return;
+        }
+
+        callback({ cancel: true });
       }
     );
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -106,6 +106,7 @@ export const initializeSettings = async (
         disconnectDiscord();
       }
     },
+    adblock: () => {},
   };
 
   await loadFromFile(SETTINGS_FILE);

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -34,6 +34,7 @@ const loadFromFile = async (file: string) => {
     OnSet.deemixIntegration(currentSettings.deemixIntegration);
     OnSet.volumePower(currentSettings.volumePower);
     OnSet.discordRPC(currentSettings.discordRPC);
+    OnSet.saveArl(currentSettings.saveArl);
   } catch {
     // eslint-disable-next-line no-console
     console.warn(`Error trying to read settings from file: ${file}`);
@@ -107,6 +108,7 @@ export const initializeSettings = async (
       }
     },
     adblock: () => {},
+    saveArl: () => {},
   };
 
   await loadFromFile(SETTINGS_FILE);

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -22,13 +22,10 @@ const loadFromFile = async (file: string) => {
   try {
     const data = await fs.readFile(file, { encoding: 'utf-8' });
 
-    currentSettings = JSON.parse(data);
-
-    Object.entries(DEFAULT_SETTINGS).forEach(([key, value]) => {
-      if (currentSettings[key as keyof Settings] === undefined) {
-        currentSettings[key as keyof Settings] = value as never;
-      }
-    });
+    currentSettings = {
+      ...DEFAULT_SETTINGS,
+      ...JSON.parse(data),
+    };
 
     OnSet.enableTray(currentSettings.enableTray);
     OnSet.closeToTray(currentSettings.closeToTray);
@@ -54,17 +51,23 @@ const createSettingsHandles = (window: BaseWindow, view: WebContentsView) => {
     return currentSettings;
   });
 
-  ipcMain.on(SETTINGS_SET_PROPERTY, (_, key: string, value) => {
-    if (key in currentSettings) {
-      currentSettings[key as keyof Settings] = value as never;
-      saveToFile(SETTINGS_FILE);
-    }
-    if (key in OnSet) {
-      OnSet[key as keyof Setters](value as never);
-    }
+  ipcMain.on(
+    SETTINGS_SET_PROPERTY,
+    <K extends keyof Settings>(
+      _: Electron.IpcMainEvent,
+      key: K,
+      value: Settings[K]
+    ) => {
+      if (key in currentSettings) {
+        currentSettings[key] = value;
+        saveToFile(SETTINGS_FILE);
+      }
 
-    view.webContents.send(SETTINGS_SET_PROPERTY, key, value);
-  });
+      OnSet[key](value);
+
+      view.webContents.send(SETTINGS_SET_PROPERTY, key, value);
+    }
+  );
 
   ipcMain.on(SETTINGS_RESET, () => {
     currentSettings = DEFAULT_SETTINGS;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -51,7 +51,7 @@ export const downloadsAPI = {
 
 export const settingsAPI = {
   getSettings: (): Promise<Settings> => ipcRenderer.invoke(SETTINGS_GET),
-  setSettingProperty: (key: string, value: unknown) =>
+  setSettingProperty: <K extends keyof Settings>(key: K, value: Settings[K]) =>
     ipcRenderer.send(SETTINGS_SET_PROPERTY, key, value),
   resetSettings: () => ipcRenderer.send(SETTINGS_RESET),
   showSettings: () => ipcRenderer.send(SETTINGS_SHOW),

--- a/src/preload_view.ts
+++ b/src/preload_view.ts
@@ -38,8 +38,10 @@ import { ZOOM_SET } from './common/channels/zoom';
 
 export const settingsAPI = {
   getSettings: (): Promise<Settings> => ipcRenderer.invoke(SETTINGS_GET),
-  onSetProperty: (callback: (key: string, value: unknown) => void) => {
-    ipcRenderer.on(SETTINGS_SET_PROPERTY, (_, key: string, value: unknown) =>
+  onSetProperty: (
+    callback: <K extends keyof Settings>(key: K, value: Settings[K]) => void
+  ) => {
+    ipcRenderer.on(SETTINGS_SET_PROPERTY, (_, key, value) =>
       callback(key, value)
     );
   },

--- a/src/renderer/components/Settings/SettingsForm.tsx
+++ b/src/renderer/components/Settings/SettingsForm.tsx
@@ -1,13 +1,10 @@
 import { useAtom } from 'jotai';
-import {
-  DEFAULT_SETTINGS,
-  SettingsProperties,
-} from '../../../common/types/settings';
+import { DEFAULT_SETTINGS, Settings } from '../../../common/types/settings';
 import { currentSettingsAtom } from '../../states/atoms';
 import Switch from './Switch';
 import NumberInput from './NumberInput';
 
-const setValue = (key: SettingsProperties, value: unknown) =>
+const setValue = <K extends keyof Settings>(key: K, value: Settings[K]) =>
   window.renderer.settingsAPI.setSettingProperty(key, value);
 
 function SettingsForm(): React.JSX.Element {

--- a/src/renderer/components/Settings/SettingsForm.tsx
+++ b/src/renderer/components/Settings/SettingsForm.tsx
@@ -93,6 +93,16 @@ function SettingsForm(): React.JSX.Element {
           setCurrentSettings({ ...currentSettings, adblock: newValue });
         }}
       />
+      <Switch
+        id="save-arl"
+        state={currentSettings.saveArl}
+        text="Save ARL cookie"
+        onChange={(newValue) => {
+          setValue('saveArl', newValue);
+          setCurrentSettings({ ...currentSettings, saveArl: newValue });
+          if (!newValue) localStorage.removeItem('arl');
+        }}
+      />
       <button
         type="button"
         className="cursor-pointer font-bold text-primary"

--- a/src/renderer/components/Settings/SettingsForm.tsx
+++ b/src/renderer/components/Settings/SettingsForm.tsx
@@ -84,6 +84,15 @@ function SettingsForm(): React.JSX.Element {
           setCurrentSettings({ ...currentSettings, discordRPC: newValue });
         }}
       />
+      <Switch
+        id="adblock"
+        state={currentSettings.adblock}
+        text="Adblock (disables podcasts)"
+        onChange={(newValue) => {
+          setValue('adblock', newValue);
+          setCurrentSettings({ ...currentSettings, adblock: newValue });
+        }}
+      />
       <button
         type="button"
         className="cursor-pointer font-bold text-primary"

--- a/src/renderer/pages/LoginPage.tsx
+++ b/src/renderer/pages/LoginPage.tsx
@@ -1,7 +1,11 @@
+import { useAtomValue } from 'jotai';
 import FormLayout from '../components/FormLayout';
 import LoginButton from '../components/LoginButton';
+import { currentSettingsAtom } from '../states/atoms';
 
 function LoginPage(): React.JSX.Element {
+  const { saveArl } = useAtomValue(currentSettingsAtom);
+
   return (
     <main className="min-h-screen flex items-center justify-center">
       <FormLayout>
@@ -23,6 +27,9 @@ function LoginPage(): React.JSX.Element {
         <form
           action={(form) => {
             const cookie = form.get('cookie')!;
+            if (saveArl) {
+              localStorage.setItem('arl', cookie.toString());
+            }
             window.renderer.loginAPI.setArl(cookie.toString());
           }}
         >
@@ -33,6 +40,7 @@ function LoginPage(): React.JSX.Element {
                 name="cookie"
                 placeholder="Enter the ARL cookie"
                 className="input w-full join-item"
+                defaultValue={saveArl ? localStorage.getItem('arl') || '' : ''}
               />
               <button type="submit" className="btn btn-secondary join-item">
                 Add cookie

--- a/src/view/settings.ts
+++ b/src/view/settings.ts
@@ -7,7 +7,7 @@ const OnSet: Setters = {
   startInTray: () => {},
   enableNotifications: () => {},
   deemixIntegration: () => {},
-  volumePower: (newValue: number) => setVolumePower(newValue),
+  volumePower: (newValue) => setVolumePower(newValue),
   discordRPC: () => {},
 };
 
@@ -22,9 +22,7 @@ export const initializeSettings = async () => {
   OnSet.volumePower(settings.volumePower);
   OnSet.discordRPC(settings.discordRPC);
 
-  window.view.settingsAPI.onSetProperty((key: string, value: unknown) => {
-    if (key in OnSet) {
-      OnSet[key as keyof Setters](value as never);
-    }
+  window.view.settingsAPI.onSetProperty((key, value) => {
+    OnSet[key](value);
   });
 };

--- a/src/view/settings.ts
+++ b/src/view/settings.ts
@@ -10,6 +10,7 @@ const OnSet: Setters = {
   volumePower: (newValue) => setVolumePower(newValue),
   discordRPC: () => {},
   adblock: () => {},
+  saveArl: () => {},
 };
 
 export const initializeSettings = async () => {
@@ -22,6 +23,7 @@ export const initializeSettings = async () => {
   OnSet.deemixIntegration(settings.deemixIntegration);
   OnSet.volumePower(settings.volumePower);
   OnSet.discordRPC(settings.discordRPC);
+  OnSet.saveArl(settings.saveArl);
 
   window.view.settingsAPI.onSetProperty((key, value) => {
     OnSet[key](value);

--- a/src/view/settings.ts
+++ b/src/view/settings.ts
@@ -9,6 +9,7 @@ const OnSet: Setters = {
   deemixIntegration: () => {},
   volumePower: (newValue) => setVolumePower(newValue),
   discordRPC: () => {},
+  adblock: () => {},
 };
 
 export const initializeSettings = async () => {


### PR DESCRIPTION
First, thank you for this amazing project.

This pull request introduces a new "Save ARL cookie" feature to the application's settings, allowing users to opt in to saving their ARL cookie in local storage for easier login. As the cookie is not checked to be correct, the ARL field will just be prefilled with the last used key.

**New "Save ARL cookie" feature:**

* Added a new `saveArl` property to the `Settings` interface and included it in `DEFAULT_SETTINGS` with a default value of `false` (`src/common/types/settings.ts`). [[1]](diffhunk://#diff-24a173cc833f90cd1231f544a7d681fb7b2e451a46f7b4041cd99d6adb77c7caR10) [[2]](diffhunk://#diff-24a173cc833f90cd1231f544a7d681fb7b2e451a46f7b4041cd99d6adb77c7caR22)
* Updated settings loading and initialization logic to handle the new `saveArl` property in both main and view processes (`src/main/settings.ts`, `src/view/settings.ts`). [[1]](diffhunk://#diff-37d9e44500adf2a90a45deec655d0d320c516f5e3d43e1e15ae87d702db52dcbR37) [[2]](diffhunk://#diff-37d9e44500adf2a90a45deec655d0d320c516f5e3d43e1e15ae87d702db52dcbR111) [[3]](diffhunk://#diff-d8e3edefcef1ddf93016ff9bd0ac09e2a0c5f65931c771d91530740abae9c358R13) [[4]](diffhunk://#diff-d8e3edefcef1ddf93016ff9bd0ac09e2a0c5f65931c771d91530740abae9c358R26)

**User interface updates:**

* Added a new switch to the settings form UI to let users enable or disable the "Save ARL cookie" feature. Disabling the switch removes the cookie from local storage (`src/renderer/components/Settings/SettingsForm.tsx`).

**Login behavior enhancements:**

* Updated the login page to:
  - Prefill the ARL input field with the saved cookie if the "Save ARL cookie" option is enabled.
  - Save the entered ARL cookie to local storage if the option is enabled, when the user logs in (`src/renderer/pages/LoginPage.tsx`). [[1]](diffhunk://#diff-a9f27356983b50e243cf1d71b49661e09a57a0cf8696032a76b63b0e9d2aba86R1-R8) [[2]](diffhunk://#diff-a9f27356983b50e243cf1d71b49661e09a57a0cf8696032a76b63b0e9d2aba86R30-R32) [[3]](diffhunk://#diff-a9f27356983b50e243cf1d71b49661e09a57a0cf8696032a76b63b0e9d2aba86R43)

These changes collectively allow users to save their ARL cookie securely and improve the login experience by optionally remembering their credentials.