### PR TITLE
Fix notifications being displayed multiple times

### DIFF
--- a/src/common/channels/notifications.ts
+++ b/src/common/channels/notifications.ts
@@ -1,3 +1,4 @@
 // Notifications from electron don't support icons via http, therefore
 // we need a channel :( https://github.com/electron/electron/pull/43377
 export const NOTIFICATIONS_CREATE = 'notifications:create';
+export const NOTIFICATIONS_TAG = 'deezer-enhanced-song-notification';

--- a/src/main/mpris.ts
+++ b/src/main/mpris.ts
@@ -85,7 +85,7 @@ const createMprisHandles = (player: Player, view: WebContentsView) => {
 
 const updateMetadataSong = (player: Player, data: Song) => {
   player.metadata = {
-    'mpris:trackid': player.objectPath('track/0'),
+    'mpris:trackid': player.objectPath(`Track/${data.SNG_ID}`),
     'mpris:length': parseFloat(data.DURATION) * 1_000_000,
     'mpris:artUrl':
       DEEZER_SONG_ART_URL + data.ALB_PICTURE + DEEZER_ART_RESOLUTION,
@@ -101,7 +101,7 @@ const updateMetadataSong = (player: Player, data: Song) => {
 
 const updateMetadataEpisode = (player: Player, data: Episode) => {
   player.metadata = {
-    'mpris:trackid': player.objectPath('track/0'),
+    'mpris:trackid': player.objectPath(`Track/${data.EPISODE_ID}`),
     'mpris:length': parseFloat(data.DURATION) * 1_000_000,
     'mpris:artUrl':
       DEEZER_EPISODE_ART_URL + data.SHOW_ART_MD5 + DEEZER_ART_RESOLUTION,
@@ -207,7 +207,7 @@ export const initializePlayer = (
   view: WebContentsView
 ) => {
   const player: Player = new Player({
-    name: 'Deezer',
+    name: 'DeezerEnhanced',
     identity: 'Deezer media player',
     supportedUriSchemes: [],
     supportedMimeTypes: [],

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,6 +8,7 @@ import { currentSettingsAtom } from './states/atoms';
 import LogPage from './pages/LogPage';
 import LogNavigation from './components/LogNavigation';
 import { NotificationData } from './components/Downloads/notifications';
+import { NOTIFICATIONS_TAG } from '../common/channels/notifications';
 
 import './index.css';
 
@@ -61,7 +62,12 @@ function App(): React.JSX.Element {
     document.addEventListener('keydown', handleKeydown);
 
     window.renderer.notificationsAPI.onNotificationCreate(
-      (title, body, icon) => new Notification(title, { body, icon })
+      (title, body, icon) =>
+        new Notification(title, {
+          body,
+          icon,
+          tag: NOTIFICATIONS_TAG,
+        })
     );
 
     window.renderer.themesAPI.onStyleChange((style) => {


### PR DESCRIPTION
This also sets `mpris:trackid` correctly to SNG_ID and EPISODE_ID. I have changed the player name to DeezerEnhanced because users may have installed the original deezer player and I wanted to remove possible naming conflicts and resulting confusion.

If we ever want to implement the Mpris Tracklist interface we have to come up with some more sophisticated method to set the `mpris:trackid` because [it may only occur once in a tracklist](https://specifications.freedesktop.org/mpris/latest/Player_Interface.html#Simple-Type:Track_Id).

Closes: #10 